### PR TITLE
fix: integrate toast message container

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { getAuth, signInAnonymously } from 'firebase/auth';
 import { app } from './firebaseConfig';
 import HomeScreen from './screens/HomeScreen';
+import Toast from 'react-native-toast-message';
 
 export default function App() {
   useEffect(() => {
@@ -9,5 +10,10 @@ export default function App() {
     signInAnonymously(auth).catch(console.error);
   }, []);
 
-  return <HomeScreen />;
+  return (
+    <>
+      <HomeScreen />
+      <Toast />
+    </>
+  );
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "geofirestore": "^5.0.0",
     "geofirestore-core": "^5.0.0",
     "react": "19.0.0",
-    "react-native": "0.79.2"
+    "react-native": "0.79.2",
+    "react-native-toast-message": "^2.1.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
## Summary
- render Toast UI at the root
- add missing dependency react-native-toast-message

## Testing
- `npm start -- --clear` *(fails: fetch failed due to network restrictions)*